### PR TITLE
Run Store tests on ObjectStore

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,7 @@ test = [
     "mypy",
     "hypothesis",
     "universal-pathlib",
+    "obstore==0.3.0b5",
 ]
 
 jupyter = [

--- a/tests/test_store/test_object.py
+++ b/tests/test_store/test_object.py
@@ -1,0 +1,7 @@
+from zarr.core.buffer import cpu
+from zarr.storage.object_store import ObjectStore
+from zarr.testing.store import StoreTests
+
+
+class TestObjectStore(StoreTests[ObjectStore, cpu.Buffer]):
+    store_cls = ObjectStore


### PR DESCRIPTION
This PR adds first tests following https://github.com/zarr-developers/zarr-python/pull/1661#issuecomment-2430146342 and adds obstore as a test dep so that ObjectStore can be tested in the CI