### PR TITLE
Catch some allowed exceptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,7 @@ keywords = ["Python", "compressed", "ndimensional-arrays", "zarr"]
 # User extras
 remote = [
     "fsspec>=2023.10.0",
-    "obstore==0.3.0b10",
+    "obstore==0.3.0",
 
 ]
 gpu = [
@@ -77,7 +77,7 @@ test = [
     "mypy",
     "hypothesis",
     "universal-pathlib",
-    "obstore==0.3.0b10",
+    "obstore==0.3.0",
 ]
 optional = ["rich", "universal-pathlib"]
 docs = [


### PR DESCRIPTION
`zarr.create_array` works with this PR. Here are a couple open questions:
1. Should allowed exceptions be constant or configurable as in the [fsspec store](https://zarr.readthedocs.io/en/stable/api/zarr/storage/index.html#zarr.storage.FsspecStore)?
2. What's the best way to catch any exceptions returned during `get_partial_values`?

Work torwards https://github.com/zarr-developers/zarr-python/pull/1661